### PR TITLE
Add midthickness files

### DIFF
--- a/tpl-fsaverage_hemi-L_den-164k_midthickness.surf.gii
+++ b/tpl-fsaverage_hemi-L_den-164k_midthickness.surf.gii
@@ -1,0 +1,1 @@
+.git/annex/objects/0X/5g/MD5E-s4322550--83b5c62111e850fe8c6b51cae6115a54.surf.gii/MD5E-s4322550--83b5c62111e850fe8c6b51cae6115a54.surf.gii

--- a/tpl-fsaverage_hemi-R_den-164k_midthickness.surf.gii
+++ b/tpl-fsaverage_hemi-R_den-164k_midthickness.surf.gii
@@ -1,0 +1,1 @@
+.git/annex/objects/vM/gg/MD5E-s4322266--7877e68f5b1394c25a92e24762674a1a.surf.gii/MD5E-s4322266--7877e68f5b1394c25a92e24762674a1a.surf.gii


### PR DESCRIPTION
Generated with mris_expand, manually edited to add secondary structure to correspond with white/pial surfaces.

Need to figure out how to push annexed objects to S3.